### PR TITLE
Add Chrome extension skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # extension-chrome-gpt-et-conversations
+
+This repository contains a minimal Chrome extension example for handling GPT conversations. The manifest defines a background service worker (`background.js`) and registers a command that can be triggered with `Ctrl+Shift+Y` by default.
+
+## Building
+
+1. Load the extension folder into Chrome via `chrome://extensions` (enable Developer mode, click "Load unpacked").
+2. Ensure the extension's service worker loads without errors.
+3. Use the keyboard shortcut or define your own in Chrome to trigger the command handler.
+

--- a/background.js
+++ b/background.js
@@ -1,0 +1,8 @@
+chrome.runtime.onInstalled.addListener(() => {
+  console.log('Extension installed');
+});
+
+chrome.commands.onCommand.addListener((command) => {
+  console.log('Command received:', command);
+});
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "GPT Conversations Extension",
+  "version": "1.0",
+  "manifest_version": 3,
+  "description": "Extension skeleton for GPT conversations.",
+  "permissions": ["commands"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "commands": {
+    "toggle-feature": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Y"
+      },
+      "description": "Toggle GPT feature"
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add a manifest defining the background service worker and command
- add a simple background script listening for command events
- document how to load and try the extension

## Testing
- `git status --short`