### PR TITLE
Fix popup width and GPT avatar display

### DIFF
--- a/content.js
+++ b/content.js
@@ -220,10 +220,24 @@ class ChatGPTScraper {
       // Catégorisation automatique basée sur le nom/description
       const category = this.categorizeGPT(name, description);
 
+      // Extraction de l'icône
+      let iconUrl = null;
+      const imgEl = element.querySelector('img');
+      if (imgEl && imgEl.src) {
+        iconUrl = imgEl.src;
+      } else {
+        const styleBg = getComputedStyle(element).backgroundImage;
+        const match = styleBg && styleBg !== 'none' ? styleBg.match(/url\("?(.*?)"?\)/) : null;
+        if (match && match[1]) {
+          iconUrl = match[1];
+        }
+      }
+
       return {
         id: gptId,
         name: name,
         description: description,
+        iconUrl: iconUrl,
         url: link,
         category: category,
         favorite: false,

--- a/options.js
+++ b/options.js
@@ -688,7 +688,7 @@ class OptionsManager {
     const container = document.getElementById('optionsGptList');
     if (!container) return;
     container.innerHTML = this.data.gpts.map(gpt => `
-      <div class="item-row"><img src="icons/icon16.png" alt="">${gpt.name}</div>
+      <div class="item-row"><img src="${gpt.iconUrl || 'icons/icon16.png'}" alt="">${gpt.name}</div>
     `).join('');
   }
 

--- a/popup.css
+++ b/popup.css
@@ -611,7 +611,7 @@ body {
 /* Responsive */
 @media (max-width: 480px) {
   body {
-    width: 100vw;
+    width: 400px;
   }
   
   .container {

--- a/popup.js
+++ b/popup.js
@@ -204,7 +204,7 @@ const SyncManager = {
     container.innerHTML = filteredGPTs.map(gpt => `
       <div class="item-card" data-id="${gpt.id}">
         <div class="item-header">
-          <div class="item-title"><img class="item-icon" src="icons/icon16.png" alt="">${gpt.name}</div>
+          <div class="item-title"><img class="item-icon" src="${gpt.iconUrl || 'icons/icon16.png'}" alt="">${gpt.name}</div>
           <div class="item-actions">
             <button class="item-btn favorite-btn ${gpt.favorite ? 'active' : ''}" title="Marquer comme favori">
               <svg width="14" height="14" viewBox="0 0 24 24" fill="${gpt.favorite ? 'currentColor' : 'none'}" stroke="currentColor">
@@ -452,6 +452,7 @@ const FormManager = {
         name: formData.get('gptName') || document.getElementById('gptName').value,
         description: formData.get('gptDescription') || document.getElementById('gptDescription').value,
         url: formData.get('gptUrl') || document.getElementById('gptUrl').value,
+        iconUrl: '',
         category: formData.get('gptCategory') || document.getElementById('gptCategory').value,
         favorite: false,
         usageCount: 0,
@@ -567,7 +568,8 @@ const NavigationManager = {
 
   setupTabNavigation() {
     document.querySelectorAll('.nav-tab').forEach(tab => {
-      tab.addEventListener('click', () => {
+      tab.addEventListener('click', (e) => {
+        e.preventDefault();
         const tabId = tab.dataset.tab;
         this.switchTab(tabId);
       });


### PR DESCRIPTION
## Summary
- keep popup width fixed on small screens
- scrape GPT avatar image and store as `iconUrl`
- display GPT avatars in the popup and options page
- ensure tab navigation doesn't break by preventing default clicks
- include placeholder `iconUrl` for manually added GPTs

## Testing
- `node --check popup.js`
- `node --check content.js`
- `node --check options.js` *(fails: Unexpected identifier)*
