### PR TITLE
Implement sync fixes and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ This repository contains a minimal Chrome extension example for handling GPT con
 ## License
 
 This project is licensed under the [MIT License](LICENSE).
+
+## Running Tests
+
+To run the small Node.js test suite:
+
+```bash
+node tests/nameParsingTest.js
+```

--- a/content.js
+++ b/content.js
@@ -1,6 +1,7 @@
 // Content Script pour ChatGPT Sync Manager
 // Ce script s'exécute dans le contexte de la page ChatGPT
 
+if (typeof window === 'undefined' || !window.ChatGPTScraper) {
 class ChatGPTScraper {
   constructor(autoInit = true) {
     this.isInitialized = false;
@@ -76,6 +77,11 @@ class ChatGPTScraper {
 
         case 'getCurrentUrl':
           sendResponse({ success: true, url: window.location.href });
+          break;
+
+        case 'renameConversation':
+          this.renameConversation(request.id, request.title);
+          sendResponse({ success: true });
           break;
 
         default:
@@ -276,7 +282,7 @@ class ChatGPTScraper {
 
     return text
       .replace(/\s+/g, ' ')
-      .replace(/[^\w\s\-.,!?()]/g, '')
+      .replace(/[^\p{L}\p{N}\s\-.,!?()]/gu, '')
       .trim()
       .substring(0, 200); // Limite la longueur
   }
@@ -460,6 +466,18 @@ class ChatGPTScraper {
     });
   }
 
+  renameConversation(id, newTitle) {
+    try {
+      const link = document.querySelector(`a[href*="/c/${id}"]`);
+      if (link) {
+        const titleEl = link.querySelector('span') || link;
+        titleEl.textContent = newTitle;
+      }
+    } catch (e) {
+      console.error('renameConversation error', e);
+    }
+  }
+
   generateId() {
     return Date.now().toString(36) + Math.random().toString(36).substr(2);
   }
@@ -497,3 +515,5 @@ if (typeof window !== 'undefined' && (window.location.hostname.includes('openai.
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = { ChatGPTScraper };
 }
+}
+

--- a/options.css
+++ b/options.css
@@ -264,6 +264,14 @@ body {
   min-width: 160px;
 }
 
+input[type="color"].setting-input {
+  padding: 0;
+  height: 36px;
+  width: 52px;
+  min-width: 52px;
+  background: none;
+}
+
 .setting-input:focus {
   outline: none;
   border-color: var(--primary-color);

--- a/tests/nameParsingTest.js
+++ b/tests/nameParsingTest.js
@@ -5,4 +5,5 @@ assert(scraper.filterFallbackName('Today') === '', 'Today should be ignored');
 assert(scraper.filterFallbackName('Hier') === '', 'Hier should be ignored');
 assert(scraper.filterFallbackName('12/01/23') === '', 'Date should be ignored');
 assert(scraper.filterFallbackName('My GPT') === 'My GPT', 'Normal name');
+assert(scraper.cleanText('Café crème') === 'Café crème', 'Accents preserved');
 console.log('Tests passed');


### PR DESCRIPTION
## Summary
- preserve accents during GPT sync
- prevent duplicate `ChatGPTScraper` injection
- show color values in options page
- open ChatGPT editor when editing a GPT
- allow renaming conversations and update ChatGPT page
- document how to run tests
- update unit test

## Testing
- `node tests/nameParsingTest.js`